### PR TITLE
Add --source-app flag to CLI send subcommand for custom focus-on-dismiss

### DIFF
--- a/Sources/Lumesent/ExternalNotification.swift
+++ b/Sources/Lumesent/ExternalNotification.swift
@@ -78,6 +78,7 @@ struct ExternalNotification: Codable {
     var alertType: String?
     var sourceContext: SourceContext?
     var focusSource: Bool?
+    var sourceApp: String?
 
     var resolvedSubtitle: String { subtitle ?? "" }
     var resolvedBody: String { body ?? "" }

--- a/Sources/Lumesent/NotificationRecord.swift
+++ b/Sources/Lumesent/NotificationRecord.swift
@@ -29,6 +29,11 @@ struct NotificationRecord: Identifiable {
 
     static func fromExternal(_ ext: ExternalNotification) -> NotificationRecord {
         externalIdCounter -= 1
+        var ctx = ext.sourceContext
+        if let sourceApp = ext.sourceApp {
+            if ctx == nil { ctx = SourceContext() }
+            ctx?.terminalAppBundleId = sourceApp
+        }
         return NotificationRecord(
             id: externalIdCounter,
             appIdentifier: "external",
@@ -37,7 +42,7 @@ struct NotificationRecord: Identifiable {
             body: ext.resolvedBody,
             deliveredDate: Date(),
             overrideAppName: ext.resolvedAppName,
-            sourceContext: ext.sourceContext
+            sourceContext: ctx
         )
     }
 

--- a/Sources/Lumesent/main.swift
+++ b/Sources/Lumesent/main.swift
@@ -103,12 +103,14 @@ if subcommand == "send" {
           --app-name <text>     App name shown in the alert (default: "External")
           --display-mode <mode> "sticky" (stays until dismissed) or "timed" (auto-dismiss)
           --alert-type <type>   "fullscreen" (default) or "notification" (native macOS notification)
+          --source-app <id>     Bundle ID of the app to focus on dismiss (e.g. "com.apple.Safari")
           --no-focus-source     Don't focus the source terminal after alert dismiss
 
         EXAMPLES
           Lumesent send --title "Build failed" --body "exit code 1"
           Lumesent send --title "Deploy complete" --app-name "CI" --display-mode sticky
           Lumesent send --title "Done!" --alert-type notification
+          Lumesent send --title "Page loaded" --source-app com.apple.Safari
 
         Bypasses filter rules — always displayed (unless paused).
         The app must already be running.
@@ -138,7 +140,8 @@ if subcommand == "send" {
         displayMode: flagValue("--display-mode"),
         alertType: flagValue("--alert-type"),
         sourceContext: SourceContext.detect(),
-        focusSource: noFocusSource ? false : nil
+        focusSource: noFocusSource ? false : nil,
+        sourceApp: flagValue("--source-app")
     )
 
     let data: Data


### PR DESCRIPTION
Allows specifying a bundle ID (e.g. com.apple.Safari) that will be focused when the notification is dismissed, instead of auto-detecting the source terminal.

Closes #3