### PR TITLE
threading: move all I/O and DB work off the main thread

### DIFF
--- a/Sources/Lumesent/AppSettings.swift
+++ b/Sources/Lumesent/AppSettings.swift
@@ -136,22 +136,26 @@ class AppSettings: ObservableObject {
     }
 
     func save() {
-        do {
-            let data = try JSONEncoder().encode(SettingsData(
-                dismissKey: dismissKey,
-                showInDock: showInDock,
-                alertPresentation: alertPresentation,
-                pauseAlertsUntil: pauseAlertsUntil,
-                socketPath: socketPath == FileLocations.defaultSocketPath ? nil : socketPath,
-                updateChannel: updateChannel == .stable ? nil : updateChannel,
-                updateCheckInterval: updateCheckInterval == .everyHour ? nil : updateCheckInterval,
-                activeWindowBehavior: activeWindowBehavior == .downgrade ? nil : activeWindowBehavior,
-                soundEnabled: soundEnabled ? true : nil,
-                alertSound: alertSound
-            ))
-            try data.write(to: fileURL, options: .atomic)
-        } catch {
-            AppLog.shared.error("Failed to save settings: \(error.localizedDescription, privacy: .public)")
+        let payload = SettingsData(
+            dismissKey: dismissKey,
+            showInDock: showInDock,
+            alertPresentation: alertPresentation,
+            pauseAlertsUntil: pauseAlertsUntil,
+            socketPath: socketPath == FileLocations.defaultSocketPath ? nil : socketPath,
+            updateChannel: updateChannel == .stable ? nil : updateChannel,
+            updateCheckInterval: updateCheckInterval == .everyHour ? nil : updateCheckInterval,
+            activeWindowBehavior: activeWindowBehavior == .downgrade ? nil : activeWindowBehavior,
+            soundEnabled: soundEnabled ? true : nil,
+            alertSound: alertSound
+        )
+        let url = fileURL
+        DispatchQueue.global(qos: .utility).async {
+            do {
+                let data = try JSONEncoder().encode(payload)
+                try data.write(to: url, options: .atomic)
+            } catch {
+                AppLog.shared.error("Failed to save settings: \(error.localizedDescription, privacy: .public)")
+            }
         }
     }
 

--- a/Sources/Lumesent/NotificationHistory.swift
+++ b/Sources/Lumesent/NotificationHistory.swift
@@ -125,7 +125,11 @@ class NotificationHistory: ObservableObject {
     /// Returns suggestions for a given field, deduplicated by value, most recent first.
     /// Each suggestion carries the most recent full entry for preview.
     func suggestions(for field: SuggestionField, matching query: String) -> [Suggestion] {
-        // Group entries by the target field value, keep most recent per unique value
+        Self.computeSuggestions(entries: entries, field: field, matching: query)
+    }
+
+    /// Pure computation on a snapshot — safe to call from any thread.
+    static func computeSuggestions(entries: [HistoryEntry], field: SuggestionField, matching query: String) -> [Suggestion] {
         var latest: [String: HistoryEntry] = [:]
         for entry in entries {
             let value = field.value(from: entry)
@@ -137,19 +141,14 @@ class NotificationHistory: ObservableObject {
             }
         }
 
-        var results = latest.values.map { entry in
-            Suggestion(displayValue: field.value(from: entry), entry: entry)
-        }
+        var results = latest.values.map { Suggestion(displayValue: field.value(from: $0), entry: $0) }
 
-        // Filter by query
         if !query.isEmpty {
             let q = query.lowercased()
             results = results.filter { $0.displayValue.lowercased().contains(q) && $0.displayValue != query }
         }
 
-        // Sort most recent first
         results.sort { $0.entry.date > $1.entry.date }
-
         return results
     }
 }
@@ -177,28 +176,39 @@ struct Suggestion: Identifiable {
 
 private extension NotificationHistory {
     func save() {
-        do {
-            let data = try JSONEncoder().encode(entries)
-            try data.write(to: fileURL, options: .atomic)
-        } catch {
-            AppLog.shared.error("Failed to save notification history: \(error.localizedDescription, privacy: .public)")
+        let snapshot = entries
+        let url = fileURL
+        DispatchQueue.global(qos: .utility).async {
+            do {
+                let data = try JSONEncoder().encode(snapshot)
+                try data.write(to: url, options: .atomic)
+            } catch {
+                AppLog.shared.error("Failed to save notification history: \(error.localizedDescription, privacy: .public)")
+            }
         }
     }
 
     func load() {
-        guard let data = try? Data(contentsOf: fileURL) else {
-            AppLog.shared.info("no history file at \(self.fileURL.path, privacy: .public), starting empty")
-            return
-        }
-        guard let decoded = try? JSONDecoder().decode([HistoryEntry].self, from: data) else {
-            AppLog.shared.error("failed to decode history from \(self.fileURL.path, privacy: .public) (\(data.count, privacy: .public) bytes)")
-            return
-        }
-        entries = decoded.count > Self.maxEntries ? Array(decoded.suffix(Self.maxEntries)) : decoded
-        AppLog.shared.info("loaded \(self.entries.count, privacy: .public) history entries (\(self.entries.filter(\.matched).count, privacy: .public) matched)")
-        if decoded.count > Self.maxEntries {
-            AppLog.shared.info("history trimmed from \(decoded.count, privacy: .public) to \(Self.maxEntries, privacy: .public)")
-            save()
+        let url = fileURL
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            guard let self else { return }
+            guard let data = try? Data(contentsOf: url) else {
+                AppLog.shared.info("no history file at \(url.path, privacy: .public), starting empty")
+                return
+            }
+            guard let decoded = try? JSONDecoder().decode([HistoryEntry].self, from: data) else {
+                AppLog.shared.error("failed to decode history from \(url.path, privacy: .public) (\(data.count, privacy: .public) bytes)")
+                return
+            }
+            let trimmed = decoded.count > Self.maxEntries ? Array(decoded.suffix(Self.maxEntries)) : decoded
+            AppLog.shared.info("loaded \(trimmed.count, privacy: .public) history entries (\(trimmed.filter(\.matched).count, privacy: .public) matched)")
+            DispatchQueue.main.async {
+                self.entries = trimmed
+                if decoded.count > Self.maxEntries {
+                    AppLog.shared.info("history trimmed from \(decoded.count, privacy: .public) to \(Self.maxEntries, privacy: .public)")
+                    self.save()
+                }
+            }
         }
     }
 }

--- a/Sources/Lumesent/NotificationMonitor.swift
+++ b/Sources/Lumesent/NotificationMonitor.swift
@@ -23,6 +23,8 @@ final class NotificationMonitor: ObservableObject {
     private var fallbackTimer: Timer?
     private var axObserver: AXObserver?
     private let dbPath: String
+    /// Serial queue for all SQLite access — keeps db/lastSeenRecId off the main thread.
+    private let dbQueue = DispatchQueue(label: "com.lumesent.notificationdb", qos: .userInitiated)
 
     init(onNewNotification: @escaping (NotificationRecord) -> Void) {
         self.onNewNotification = onNewNotification
@@ -32,9 +34,12 @@ final class NotificationMonitor: ObservableObject {
 
     func start() {
         AppLog.shared.info("NotificationMonitor starting — dbPath=\(self.dbPath, privacy: .public)")
-        tryOpenDatabase()
-        if db != nil {
-            initializeLastSeenIdIfNeeded()
+        dbQueue.async { [weak self] in
+            guard let self else { return }
+            self.tryOpenDatabase()
+            if self.db != nil {
+                self.initializeLastSeenIdIfNeeded()
+            }
         }
         startAccessibilityObserver()
         startFallbackTimer()
@@ -89,9 +94,9 @@ final class NotificationMonitor: ObservableObject {
         AppLog.shared.info("initialized, last rec_id = \(self.lastSeenRecId, privacy: .public)")
     }
 
-    /// Returns `true` if at least one new notification was found.
+    /// Must be called on `dbQueue`. Returns `true` if at least one new notification was found.
     @discardableResult
-    func fetchNewNotifications() -> Bool {
+    private func fetchNewNotificationsOnQueue() -> Bool {
         guard let db else { return false }
 
         // Ensure we see the latest WAL frames by resetting the read transaction.
@@ -161,10 +166,11 @@ final class NotificationMonitor: ObservableObject {
             fetchCount += 1
             lastSeenRecId = recId
             AppLog.shared.info("fetched notification rec_id=\(recId, privacy: .public) app=\(appIdentifier, privacy: .public) title=\(title, privacy: .public) subtitle=\(subtitle, privacy: .public) body=\(body.prefix(80), privacy: .public) delivered=\(deliveredDate.description, privacy: .public)")
-            onNewNotification(record)
+            let callback = onNewNotification
+            DispatchQueue.main.async { callback(record) }
         }
         if fetchCount > 0 {
-            AppLog.shared.info("fetchNewNotifications: \(fetchCount, privacy: .public) new notification(s), lastSeenRecId=\(self.lastSeenRecId, privacy: .public)")
+            AppLog.shared.info("fetchNewNotificationsOnQueue: \(fetchCount, privacy: .public) new notification(s), lastSeenRecId=\(self.lastSeenRecId, privacy: .public)")
         }
         return foundAny
     }
@@ -202,12 +208,12 @@ final class NotificationMonitor: ObservableObject {
         let callback: AXObserverCallback = { _, _, _, refcon in
             guard let refcon else { return }
             let monitor = Unmanaged<NotificationMonitor>.fromOpaque(refcon).takeUnretainedValue()
-            DispatchQueue.main.async {
-                let found = monitor.fetchNewNotifications()
+            monitor.dbQueue.async {
+                let found = monitor.fetchNewNotificationsOnQueue()
                 if !found {
                     // DB row may not be committed yet; retry once after a short delay.
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                        monitor.fetchNewNotifications()
+                        monitor.dbQueue.async { monitor.fetchNewNotificationsOnQueue() }
                     }
                 }
             }
@@ -249,18 +255,23 @@ final class NotificationMonitor: ObservableObject {
         AppLog.shared.info("fallback poll timer started (2s interval)")
         fallbackTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
             guard let self else { return }
+            // AX observer check stays on main — axObserver is only touched on main.
             if self.axObserver == nil && AXIsProcessTrusted() {
                 AppLog.shared.info("fallback timer: AX now trusted, retrying observer setup")
                 self.startAccessibilityObserver()
             }
-            if self.db == nil {
-                AppLog.shared.debug("fallback timer: DB not open, attempting reconnect")
-                self.tryOpenDatabase()
-                if self.db != nil {
-                    self.initializeLastSeenIdIfNeeded()
+            // DB work goes to the serial dbQueue.
+            self.dbQueue.async { [weak self] in
+                guard let self else { return }
+                if self.db == nil {
+                    AppLog.shared.debug("fallback timer: DB not open, attempting reconnect")
+                    self.tryOpenDatabase()
+                    if self.db != nil {
+                        self.initializeLastSeenIdIfNeeded()
+                    }
                 }
+                self.fetchNewNotificationsOnQueue()
             }
-            self.fetchNewNotifications()
         }
     }
 }

--- a/Sources/Lumesent/RuleStore.swift
+++ b/Sources/Lumesent/RuleStore.swift
@@ -11,11 +11,15 @@ class RuleStore: ObservableObject {
     }
 
     func save() {
-        do {
-            let data = try JSONEncoder().encode(rules)
-            try data.write(to: fileURL, options: .atomic)
-        } catch {
-            AppLog.shared.error("Failed to save rules: \(error.localizedDescription, privacy: .public)")
+        let snapshot = rules
+        let url = fileURL
+        DispatchQueue.global(qos: .utility).async {
+            do {
+                let data = try JSONEncoder().encode(snapshot)
+                try data.write(to: url, options: .atomic)
+            } catch {
+                AppLog.shared.error("Failed to save rules: \(error.localizedDescription, privacy: .public)")
+            }
         }
     }
 

--- a/Sources/Lumesent/SettingsView.swift
+++ b/Sources/Lumesent/SettingsView.swift
@@ -1596,6 +1596,7 @@ struct SuggestingField<LabelAccessory: View>: View {
 
     @FocusState private var isFocused: Bool
     @State private var showSuggestions = false
+    @State private var suggestions: [Suggestion] = []
 
     init(_ label: String, text: Binding<String>, placeholder: String, history: NotificationHistory, field: SuggestionField, suggestionLeadingInset: CGFloat = 88, @ViewBuilder labelAccessory: @escaping () -> LabelAccessory) {
         self.label = label
@@ -1605,10 +1606,6 @@ struct SuggestingField<LabelAccessory: View>: View {
         self.field = field
         self.suggestionLeadingInset = suggestionLeadingInset
         self.labelAccessory = labelAccessory
-    }
-
-    private var suggestions: [Suggestion] {
-        history.suggestions(for: field, matching: text)
     }
 
     var body: some View {
@@ -1627,14 +1624,30 @@ struct SuggestingField<LabelAccessory: View>: View {
                     .onChange(of: isFocused) { _, focused in
                         if focused {
                             showSuggestions = true
+                            let snapshot = history.entries
+                            let f = field, t = text
+                            Task {
+                                let result = await Task.detached(priority: .userInitiated) {
+                                    NotificationHistory.computeSuggestions(entries: snapshot, field: f, matching: t)
+                                }.value
+                                suggestions = result
+                            }
                         } else {
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                                 showSuggestions = false
                             }
                         }
                     }
-                    .onChange(of: text) { _, _ in
+                    .onChange(of: text) { _, newText in
                         showSuggestions = isFocused
+                        let snapshot = history.entries
+                        let f = field
+                        Task {
+                            let result = await Task.detached(priority: .userInitiated) {
+                                NotificationHistory.computeSuggestions(entries: snapshot, field: f, matching: newText)
+                            }.value
+                            suggestions = result
+                        }
                     }
             }
 


### PR DESCRIPTION
Text fields were sluggish because SuggestingField computed suggestions synchronously on the main thread (iterating up to 1000 history entries per keystroke), and every save() call blocked the main thread with JSON encoding + file writes.

- SuggestingField: replace synchronous computed `suggestions` with @State populated via Task.detached so suggestion lookups never block the UI thread.
- NotificationHistory: save() snapshots entries and writes on a utility background queue; load() reads and decodes off-main then dispatches the result back to main.
- AppSettings.save(), RuleStore.save(): same pattern — snapshot on main, encode+write on a utility background queue.
- NotificationMonitor: introduce a serial `dbQueue` for all SQLite work (open, prime, fetch, close). fetchNewNotifications renamed to fetchNewNotificationsOnQueue (private); each found record is dispatched back to main via the existing onNewNotification callback. The 2s fallback timer and AXObserver callback now dispatch DB work to dbQueue instead of running it on the main runloop.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

https://claude.ai/code/session_014pb5LAs6U2mxtMrgEdSZLA